### PR TITLE
fix/projectile_destroyed_parent_call

### DIFF
--- a/Source/GASExtensions/Private/Projectiles/GASExtProjectile.cpp
+++ b/Source/GASExtensions/Private/Projectiles/GASExtProjectile.cpp
@@ -82,8 +82,6 @@ void AGASExtProjectile::BeginPlay()
 
 void AGASExtProjectile::Destroyed()
 {
-    Super::Destroyed();
-
     ExecuteGameplayCue( DestroyedGameplayCue, [ projectile = this ]( FGameplayCueParameters & gameplay_cue_parameters ) {
         projectile->UpdateDestroyedGameplayCueParameters( gameplay_cue_parameters );
     } );
@@ -95,6 +93,8 @@ void AGASExtProjectile::Destroyed()
 
     // :NOTE: Don't forget to add timers using a reference to this, and not lambdas, or they won't be cleared at all
     GetWorldTimerManager().ClearAllTimersForObject( this );
+
+    Super::Destroyed();
 }
 
 void AGASExtProjectile::Release( float /*time_held*/ )


### PR DESCRIPTION
Parent call must be at the end, so that we can do stuff in blueprint first too