### PR TITLE
feature/bttask_sendgameplayevent_dynamic_options

### DIFF
--- a/Source/GASExtensions/Private/AI/GASExtBTTask_TryActivateAbility.cpp
+++ b/Source/GASExtensions/Private/AI/GASExtBTTask_TryActivateAbility.cpp
@@ -229,6 +229,11 @@ EBTNodeResult::Type UGASExtBTTask_TryActivateAbilityByTag::TryActivateAbility( U
     return EBTNodeResult::Failed;
 }
 
+FGASExtBTTaskSendGameplayEventAsset::FGASExtBTTaskSendGameplayEventAsset() :
+    AssetSource( EGASExtBTTaskSendGameplayEventAssetSource::None ),
+    Asset( nullptr )
+{}
+
 UGASExtBTTask_SendGameplayEvent::UGASExtBTTask_SendGameplayEvent( const FObjectInitializer & object_initializer ) :
     Super( object_initializer )
 {

--- a/Source/GASExtensions/Public/AI/GASExtBTTask_TryActivateAbility.h
+++ b/Source/GASExtensions/Public/AI/GASExtBTTask_TryActivateAbility.h
@@ -97,6 +97,8 @@ struct FGASExtBTTaskSendGameplayEventAsset
 {
     GENERATED_USTRUCT_BODY()
 
+    FGASExtBTTaskSendGameplayEventAsset();
+
     UPROPERTY( EditAnywhere )
     EGASExtBTTaskSendGameplayEventAssetSource AssetSource;
 

--- a/Source/GASExtensions/Public/AI/GASExtBTTask_TryActivateAbility.h
+++ b/Source/GASExtensions/Public/AI/GASExtBTTask_TryActivateAbility.h
@@ -59,7 +59,7 @@ protected:
     EBTNodeResult::Type TryActivateAbility( UBehaviorTreeComponent & owner_comp, UAbilitySystemComponent & asc, FGASExtTryActivateAbilityBTTaskMemory * memory ) override;
 
 private:
-    UPROPERTY( Category = Node, EditAnywhere )
+    UPROPERTY( Category = "Ability", EditAnywhere )
     TSubclassOf< UGameplayAbility > AbilityClass;
 };
 
@@ -80,8 +80,31 @@ protected:
     EBTNodeResult::Type TryActivateAbility( UBehaviorTreeComponent & owner_comp, UAbilitySystemComponent & asc, FGASExtTryActivateAbilityBTTaskMemory * memory ) override;
 
 private:
-    UPROPERTY( Category = Node, EditAnywhere )
+    UPROPERTY( Category = "Ability", EditAnywhere )
     FGameplayTagContainer TagContainer;
+};
+
+UENUM()
+enum class EGASExtBTTaskSendGameplayEventAssetSource : uint8
+{
+    None,
+    FromBlackboard,
+    FromReference
+};
+
+USTRUCT()
+struct FGASExtBTTaskSendGameplayEventAsset
+{
+    GENERATED_USTRUCT_BODY()
+
+    UPROPERTY( EditAnywhere )
+    EGASExtBTTaskSendGameplayEventAssetSource AssetSource;
+
+    UPROPERTY( EditAnywhere, meta = ( EditCondition = "AssetSource == EGASExtBTTaskSendGameplayEventAssetSource::FromBlackboard" ) )
+    FBlackboardKeySelector BlackboardKey;
+
+    UPROPERTY( EditAnywhere, meta = ( EditCondition = "AssetSource == EGASExtBTTaskSendGameplayEventAssetSource::FromReference" ) )
+    UObject * Asset;
 };
 
 UCLASS()
@@ -96,9 +119,29 @@ public:
     FString GetDetailedStaticDescription() const override;
 
 private:
-    UPROPERTY( Category = Node, EditAnywhere )
+    UPROPERTY( EditAnywhere, Category = "Payload Data" )
     FGameplayTag TriggerTag;
 
-    UPROPERTY( Category = Node, EditAnywhere )
+    UPROPERTY( EditAnywhere, Category = "Payload Data" )
+    FGASExtBTTaskSendGameplayEventAsset Instigator;
+
+    UPROPERTY( EditAnywhere, Category = "Payload Data" )
+    FGASExtBTTaskSendGameplayEventAsset Target;
+
+    UPROPERTY( EditAnywhere, Category = "Payload Data" )
+    FGASExtBTTaskSendGameplayEventAsset OptionalObject1;
+
+    UPROPERTY( EditAnywhere, Category = "Payload Data" )
+    FGASExtBTTaskSendGameplayEventAsset OptionalObject2;
+
+    UPROPERTY( EditAnywhere, Category = "Payload Data" )
+    FGameplayTagContainer InstigatorTags;
+
+    UPROPERTY( EditAnywhere, Category = "Payload Data" )
+    FGameplayTagContainer TargetTags;
+
+    UPROPERTY( EditAnywhere, Category = "Payload Data" )
+    float EventMagnitude;
+
     FGameplayEventData Payload;
 };


### PR DESCRIPTION
Allows to configure at runtime the payload of the gameplay event data