### PR TITLE
fix/sphere_overlap_line_of_sight

### DIFF
--- a/Source/GASExtensions/Private/Targeting/GASExtTargetType.cpp
+++ b/Source/GASExtensions/Private/Targeting/GASExtTargetType.cpp
@@ -48,11 +48,13 @@ FGameplayAbilityTargetDataHandle UGASExtTargetType_SphereOverlapAtHitResult::Get
 
     if ( bMustHaveLineOfSight )
     {
-        const auto ignore_actors = hit_actors;
 
         for ( auto index = hit_actors.Num() - 1; index >= 0; --index )
         {
-            const auto * hit_actor = hit_actors[ index ];
+            auto * hit_actor = hit_actors[ index ];
+
+            auto ignore_actors = hit_actors;
+            ignore_actors.RemoveSwap( hit_actor );
 
             FHitResult line_trace_hit;
             UKismetSystemLibrary::LineTraceSingle( ability_owner,
@@ -70,7 +72,7 @@ FGameplayAbilityTargetDataHandle UGASExtTargetType_SphereOverlapAtHitResult::Get
 
             if ( line_trace_hit.bBlockingHit && line_trace_hit.GetActor() != hit_actor )
             {
-                hit_actors.RemoveAt( index );
+                hit_actors.RemoveAtSwap( index );
             }
         }
     }


### PR DESCRIPTION
Make sure we don't add the current hit actor to the ignore actors. This way we can check if the first thing it hit is the actor itself, instead of it being able to hit the ground underneath the actor and returning false.