### PR TITLE
ability sets

### DIFF
--- a/Source/GASExtensions/Private/Abilities/GASExtAbilitySet.cpp
+++ b/Source/GASExtensions/Private/Abilities/GASExtAbilitySet.cpp
@@ -1,0 +1,136 @@
+#include "Abilities/GASExtAbilitySet.h"
+
+#include "GASExtLog.h"
+
+void FGASExtAbilitySet_GrantedHandles::AddAbilitySpecHandle( const FGameplayAbilitySpecHandle & handle )
+{
+    if ( handle.IsValid() )
+    {
+        AbilitySpecHandles.Add( handle );
+    }
+}
+
+void FGASExtAbilitySet_GrantedHandles::AddGameplayEffectHandle( const FActiveGameplayEffectHandle & handle )
+{
+    if ( handle.IsValid() )
+    {
+        GameplayEffectHandles.Add( handle );
+    }
+}
+
+void FGASExtAbilitySet_GrantedHandles::AddAttributeSet( UAttributeSet * set )
+{
+    GrantedAttributeSets.Add( set );
+}
+
+void FGASExtAbilitySet_GrantedHandles::TakeFromAbilitySystem( UGASExtAbilitySystemComponent * asc )
+{
+    check( asc );
+
+    if ( !asc->IsOwnerActorAuthoritative() )
+    {
+        // Must be authoritative to give or take ability sets.
+        return;
+    }
+
+    for ( const FGameplayAbilitySpecHandle & handle : AbilitySpecHandles )
+    {
+        if ( handle.IsValid() )
+        {
+            asc->ClearAbility( handle );
+        }
+    }
+
+    for ( const FActiveGameplayEffectHandle & handle : GameplayEffectHandles )
+    {
+        if ( handle.IsValid() )
+        {
+            asc->RemoveActiveGameplayEffect( handle );
+        }
+    }
+
+    for ( UAttributeSet * set : GrantedAttributeSets )
+    {
+        asc->GetSpawnedAttributes_Mutable().Remove( set );
+    }
+
+    AbilitySpecHandles.Reset();
+    GameplayEffectHandles.Reset();
+    GrantedAttributeSets.Reset();
+}
+
+void UGASExtAbilitySet::GiveToAbilitySystem( UGASExtAbilitySystemComponent * asc, FGASExtAbilitySet_GrantedHandles * out_granted_handles, UObject * source_object ) const
+{
+    check( asc );
+
+    if ( !asc->IsOwnerActorAuthoritative() )
+    {
+        // Must be authoritative to give or take ability sets.
+        return;
+    }
+
+    // Grant the gameplay abilities.
+    for ( auto ability_index = 0; ability_index < GrantedGameplayAbilities.Num(); ++ability_index )
+    {
+        const auto & ability_to_grant = GrantedGameplayAbilities[ ability_index ];
+
+        if ( !IsValid( ability_to_grant.Ability ) )
+        {
+            UE_LOG( LogGASExt, Error, TEXT( "GrantedGameplayAbilities[%d] on ability set [%s] is not valid." ), ability_index, *GetNameSafe( this ) );
+            continue;
+        }
+
+        auto * ability_cdo = ability_to_grant.Ability->GetDefaultObject< UGameplayAbility >();
+
+        FGameplayAbilitySpec ability_spec( ability_cdo, ability_to_grant.AbilityLevel );
+        ability_spec.SourceObject = source_object;
+        ability_spec.DynamicAbilityTags.AddTag( ability_to_grant.InputTag );
+
+        const auto ability_spec_handle = asc->GiveAbility( ability_spec );
+
+        if ( out_granted_handles != nullptr )
+        {
+            out_granted_handles->AddAbilitySpecHandle( ability_spec_handle );
+        }
+    }
+
+    // Grant the gameplay effects.
+    for ( int32 effect_index = 0; effect_index < GrantedGameplayEffects.Num(); ++effect_index )
+    {
+        const auto & effect_to_grant = GrantedGameplayEffects[ effect_index ];
+
+        if ( !IsValid( effect_to_grant.GameplayEffect ) )
+        {
+            UE_LOG( LogGASExt, Error, TEXT( "GrantedGameplayEffects[%d] on ability set [%s] is not valid" ), effect_index, *GetNameSafe( this ) );
+            continue;
+        }
+
+        const auto * gameplay_effect = effect_to_grant.GameplayEffect->GetDefaultObject< UGameplayEffect >();
+        const auto gameplay_effect_handle = asc->ApplyGameplayEffectToSelf( gameplay_effect, effect_to_grant.EffectLevel, asc->MakeEffectContext() );
+
+        if ( out_granted_handles != nullptr )
+        {
+            out_granted_handles->AddGameplayEffectHandle( gameplay_effect_handle );
+        }
+    }
+
+    // Grant the attribute sets.
+    for ( auto set_index = 0; set_index < GrantedAttributes.Num(); ++set_index )
+    {
+        const auto & set_to_grant = GrantedAttributes[ set_index ];
+
+        if ( !IsValid( set_to_grant.AttributeSet ) )
+        {
+            UE_LOG( LogGASExt, Error, TEXT( "GrantedAttributes[%d] on ability set [%s] is not valid" ), set_index, *GetNameSafe( this ) );
+            continue;
+        }
+
+        auto * new_set = NewObject< UAttributeSet >( asc->GetOwner(), set_to_grant.AttributeSet );
+        asc->AddAttributeSetSubobject( new_set );
+
+        if ( out_granted_handles != nullptr )
+        {
+            out_granted_handles->AddAttributeSet( new_set );
+        }
+    }
+}

--- a/Source/GASExtensions/Private/Abilities/GASExtAbilitySet.cpp
+++ b/Source/GASExtensions/Private/Abilities/GASExtAbilitySet.cpp
@@ -23,7 +23,7 @@ void FGASExtAbilitySet_GrantedHandles::AddAttributeSet( UAttributeSet * set )
     GrantedAttributeSets.Add( set );
 }
 
-void FGASExtAbilitySet_GrantedHandles::TakeFromAbilitySystem( UGASExtAbilitySystemComponent * asc )
+void FGASExtAbilitySet_GrantedHandles::TakeFromAbilitySystem( UAbilitySystemComponent * asc )
 {
     check( asc );
 
@@ -59,7 +59,7 @@ void FGASExtAbilitySet_GrantedHandles::TakeFromAbilitySystem( UGASExtAbilitySyst
     GrantedAttributeSets.Reset();
 }
 
-void UGASExtAbilitySet::GiveToAbilitySystem( UGASExtAbilitySystemComponent * asc, FGASExtAbilitySet_GrantedHandles * out_granted_handles, UObject * source_object ) const
+void UGASExtAbilitySet::GiveToAbilitySystem( UAbilitySystemComponent * asc, FGASExtAbilitySet_GrantedHandles * out_granted_handles, UObject * source_object ) const
 {
     check( asc );
 

--- a/Source/GASExtensions/Private/Abilities/GASExtAbilitySet.cpp
+++ b/Source/GASExtensions/Private/Abilities/GASExtAbilitySet.cpp
@@ -85,6 +85,7 @@ void UGASExtAbilitySet::GiveToAbilitySystem( UAbilitySystemComponent * asc, FGAS
         FGameplayAbilitySpec ability_spec( ability_cdo, ability_to_grant.AbilityLevel );
         ability_spec.SourceObject = source_object;
         ability_spec.DynamicAbilityTags.AddTag( ability_to_grant.InputTag );
+        ability_spec.InputID = ability_to_grant.InputId;
 
         const auto ability_spec_handle = asc->GiveAbility( ability_spec );
 

--- a/Source/GASExtensions/Private/Abilities/GASExtAbilitySet.cpp
+++ b/Source/GASExtensions/Private/Abilities/GASExtAbilitySet.cpp
@@ -33,7 +33,7 @@ void FGASExtAbilitySet_GrantedHandles::TakeFromAbilitySystem( UAbilitySystemComp
         return;
     }
 
-    for ( const FGameplayAbilitySpecHandle & handle : AbilitySpecHandles )
+    for ( const auto & handle : AbilitySpecHandles )
     {
         if ( handle.IsValid() )
         {
@@ -41,7 +41,7 @@ void FGASExtAbilitySet_GrantedHandles::TakeFromAbilitySystem( UAbilitySystemComp
         }
     }
 
-    for ( const FActiveGameplayEffectHandle & handle : GameplayEffectHandles )
+    for ( const auto & handle : GameplayEffectHandles )
     {
         if ( handle.IsValid() )
         {
@@ -49,7 +49,7 @@ void FGASExtAbilitySet_GrantedHandles::TakeFromAbilitySystem( UAbilitySystemComp
         }
     }
 
-    for ( UAttributeSet * set : GrantedAttributeSets )
+    for ( auto * set : GrantedAttributeSets )
     {
         asc->GetSpawnedAttributes_Mutable().Remove( set );
     }
@@ -96,7 +96,7 @@ void UGASExtAbilitySet::GiveToAbilitySystem( UAbilitySystemComponent * asc, FGAS
     }
 
     // Grant the gameplay effects.
-    for ( int32 effect_index = 0; effect_index < GrantedGameplayEffects.Num(); ++effect_index )
+    for ( auto effect_index = 0; effect_index < GrantedGameplayEffects.Num(); ++effect_index )
     {
         const auto & effect_to_grant = GrantedGameplayEffects[ effect_index ];
 

--- a/Source/GASExtensions/Private/Components/GASExtAbilitySystemComponent.cpp
+++ b/Source/GASExtensions/Private/Components/GASExtAbilitySystemComponent.cpp
@@ -244,8 +244,6 @@ EDataValidationResult UGASExtAbilitySystemComponent::IsDataValid( TArray< FText 
     Super::IsDataValid( validation_errors );
 
     return FDVEDataValidator( validation_errors )
-        .NoNullItem( VALIDATOR_GET_PROPERTY( DefaultEffects ) )
-        .NoNullItem( VALIDATOR_GET_PROPERTY( DefaultAbilities ) )
         .Result();
 }
 #endif
@@ -645,54 +643,6 @@ void UGASExtAbilitySystemComponent::GiveAbilitySet()
     if ( AbilitySet != nullptr )
     {
         AbilitySet->GiveToAbilitySystem( this, nullptr );
-    }
-}
-
-void UGASExtAbilitySystemComponent::GiveDefaultAbilities()
-{
-    if ( !GetOwner()->HasAuthority() )
-    {
-        return;
-    }
-
-    for ( const auto & startup_ability : DefaultAbilities )
-    {
-        if ( !ensureAlwaysMsgf( startup_ability != nullptr, TEXT( "%s() One of the DefaultAbilities is not valid in %s." ), TEXT( __FUNCTION__ ), *GetName() ) )
-        {
-            continue;
-        }
-
-        GiveAbility( FGameplayAbilitySpec(
-            startup_ability,
-            1,
-            startup_ability->GetDefaultObject< UGASExtGameplayAbility >()->GetInputID(),
-            this ) );
-    }
-}
-
-void UGASExtAbilitySystemComponent::GiveDefaultEffects()
-{
-    if ( !GetOwner()->HasAuthority() )
-    {
-        return;
-    }
-
-    auto effect_context = MakeEffectContext();
-    effect_context.AddSourceObject( this );
-
-    for ( const auto & startup_effect : DefaultEffects )
-    {
-        if ( !ensureAlwaysMsgf( startup_effect != nullptr, TEXT( "%s() One of the StartupEffects is not valid in %s." ), TEXT( __FUNCTION__ ), *GetName() ) )
-        {
-            continue;
-        }
-
-        const auto new_handle = MakeOutgoingSpec( startup_effect, 1, effect_context );
-
-        if ( new_handle.IsValid() )
-        {
-            ApplyGameplayEffectSpecToTarget( *new_handle.Data.Get(), this );
-        }
     }
 }
 

--- a/Source/GASExtensions/Private/Components/GASExtAbilitySystemComponent.cpp
+++ b/Source/GASExtensions/Private/Components/GASExtAbilitySystemComponent.cpp
@@ -630,7 +630,9 @@ void UGASExtAbilitySystemComponent::GiveAbilitySet()
         return;
     }
 
+    for ( const auto * ability_set : AbilitySets )
     {
+        ability_set->GiveToAbilitySystem( this, nullptr );
     }
 }
 

--- a/Source/GASExtensions/Private/Components/GASExtAbilitySystemComponent.cpp
+++ b/Source/GASExtensions/Private/Components/GASExtAbilitySystemComponent.cpp
@@ -4,6 +4,7 @@
 #include "Abilities/GASExtGameplayAbility.h"
 #include "Animation/GASExtAnimInstance.h"
 #include "DVEDataValidator.h"
+#include "Abilities/GASExtAbilitySet.h"
 
 #include <AbilitySystemGlobals.h>
 #include <Animation/AnimInstance.h>
@@ -79,9 +80,11 @@ void UGASExtAbilitySystemComponent::BeginPlay()
 
     if ( bGiveAbilitiesAndEffectsInBeginPlay )
     {
-        GiveDefaultAbilities();
+        GiveAbilitySet();
+
+        /*GiveDefaultAbilities();
         GiveDefaultEffects();
-        GiveDefaultAttributes();
+        GiveDefaultAttributes();*/
     }
 
     AddLooseGameplayTags( LooseTagsContainer );
@@ -630,6 +633,19 @@ float UGASExtAbilitySystemComponent::GetCurrentMontageSectionTimeLeftForMesh( US
     }
 
     return -1.f;
+}
+
+void UGASExtAbilitySystemComponent::GiveAbilitySet()
+{
+    if ( !GetOwner()->HasAuthority() )
+    {
+        return;
+    }
+
+    if ( AbilitySet != nullptr )
+    {
+        AbilitySet->GiveToAbilitySystem( this, nullptr );
+    }
 }
 
 void UGASExtAbilitySystemComponent::GiveDefaultAbilities()

--- a/Source/GASExtensions/Private/Components/GASExtAbilitySystemComponent.cpp
+++ b/Source/GASExtensions/Private/Components/GASExtAbilitySystemComponent.cpp
@@ -66,12 +66,6 @@ UGASExtAbilitySystemComponent::UGASExtAbilitySystemComponent()
 void UGASExtAbilitySystemComponent::InitializeComponent()
 {
     Super::InitializeComponent();
-
-    for ( const auto & attribute_set_class : AdditionalAttributeSetClass )
-    {
-        auto * attribute_set = NewObject< UAttributeSet >( GetOwner(), attribute_set_class );
-        AddAttributeSetSubobject( attribute_set );
-    }
 }
 
 void UGASExtAbilitySystemComponent::BeginPlay()
@@ -81,10 +75,6 @@ void UGASExtAbilitySystemComponent::BeginPlay()
     if ( bGiveAbilitiesAndEffectsInBeginPlay )
     {
         GiveAbilitySet();
-
-        /*GiveDefaultAbilities();
-        GiveDefaultEffects();
-        GiveDefaultAttributes();*/
     }
 
     AddLooseGameplayTags( LooseTagsContainer );
@@ -640,29 +630,7 @@ void UGASExtAbilitySystemComponent::GiveAbilitySet()
         return;
     }
 
-    if ( AbilitySet != nullptr )
     {
-        AbilitySet->GiveToAbilitySystem( this, nullptr );
-    }
-}
-
-void UGASExtAbilitySystemComponent::GiveDefaultAttributes()
-{
-    if ( DefaultAttributes == nullptr )
-    {
-        UE_LOG( LogTemp, Verbose, TEXT( "%s() Missing DefaultAttributes for %s." ), TEXT( __FUNCTION__ ), *GetNameSafe( GetOwner() ) );
-        return;
-    }
-
-    // Can run on Server and Client
-    auto effect_context = MakeEffectContext();
-    effect_context.AddSourceObject( this );
-
-    const auto new_handle = MakeOutgoingSpec( DefaultAttributes, 1, effect_context );
-
-    if ( new_handle.IsValid() )
-    {
-        ApplyGameplayEffectSpecToSelf( *new_handle.Data.Get() );
     }
 }
 

--- a/Source/GASExtensions/Private/GameFeatures/GASExtGameFeatureAction_AddAbilities.cpp
+++ b/Source/GASExtensions/Private/GameFeatures/GASExtGameFeatureAction_AddAbilities.cpp
@@ -1,15 +1,15 @@
-#include "GameFeatures/GASExtGameFeatureAction_Grant.h"
+#include "GameFeatures/GASExtGameFeatureAction_AddAbilities.h"
 
 #include "DVEDataValidator.h"
 
 #include <Engine/AssetManager.h>
 #include <GameFeaturesSubsystemSettings.h>
 
-#define LOCTEXT_NAMESPACE "UGASExtGameFeatureAction_Grant"
+#define LOCTEXT_NAMESPACE "UGASExtGameFeatureAction_AddAbilities"
 
-const FName UGASExtGameFeatureAction_Grant::NAME_AbilityReady( "AbilitiesReady" );
+const FName UGASExtGameFeatureAction_AddAbilities::NAME_AbilityReady( "AbilitiesReady" );
 
-void UGASExtGameFeatureAction_Grant::OnGameFeatureActivating()
+void UGASExtGameFeatureAction_AddAbilities::OnGameFeatureActivating()
 {
     if ( !ensureAlways( ActiveExtensions.Num() == 0 ) ||
          !ensureAlways( ComponentRequests.Num() == 0 ) )
@@ -19,14 +19,14 @@ void UGASExtGameFeatureAction_Grant::OnGameFeatureActivating()
     Super::OnGameFeatureActivating();
 }
 
-void UGASExtGameFeatureAction_Grant::OnGameFeatureDeactivating( FGameFeatureDeactivatingContext & context )
+void UGASExtGameFeatureAction_AddAbilities::OnGameFeatureDeactivating( FGameFeatureDeactivatingContext & context )
 {
     Super::OnGameFeatureDeactivating( context );
     Reset();
 }
 
 #if WITH_EDITORONLY_DATA
-void UGASExtGameFeatureAction_Grant::AddAdditionalAssetBundleData( FAssetBundleData & asset_bundle_data )
+void UGASExtGameFeatureAction_AddAbilities::AddAdditionalAssetBundleData( FAssetBundleData & asset_bundle_data )
 {
     if ( UAssetManager::IsValid() )
     {
@@ -67,7 +67,7 @@ void UGASExtGameFeatureAction_Grant::AddAdditionalAssetBundleData( FAssetBundleD
 #endif
 
 #if WITH_EDITOR
-EDataValidationResult UGASExtGameFeatureAction_Grant::IsDataValid( TArray< FText > & validation_errors )
+EDataValidationResult UGASExtGameFeatureAction_AddAbilities::IsDataValid( TArray< FText > & validation_errors )
 {
     return FDVEDataValidator( validation_errors )
         .CustomValidation< TArray< FGASExtGameFeatureAbilitiesEntry > >( AbilitiesList, []( TArray< FText > & errors, TArray< FGASExtGameFeatureAbilitiesEntry > abilities_list ) {
@@ -125,7 +125,7 @@ EDataValidationResult UGASExtGameFeatureAction_Grant::IsDataValid( TArray< FText
 }
 #endif
 
-void UGASExtGameFeatureAction_Grant::AddToWorld( const FWorldContext & world_context )
+void UGASExtGameFeatureAction_AddAbilities::AddToWorld( const FWorldContext & world_context )
 {
     if ( const auto * world = world_context.World() )
     {
@@ -158,7 +158,7 @@ void UGASExtGameFeatureAction_Grant::AddToWorld( const FWorldContext & world_con
     }
 }
 
-void UGASExtGameFeatureAction_Grant::Reset()
+void UGASExtGameFeatureAction_AddAbilities::Reset()
 {
     while ( ActiveExtensions.Num() > 0 )
     {
@@ -169,7 +169,7 @@ void UGASExtGameFeatureAction_Grant::Reset()
     ComponentRequests.Empty();
 }
 
-void UGASExtGameFeatureAction_Grant::HandleActorExtension( AActor * actor, FName event_name, int32 entry_index )
+void UGASExtGameFeatureAction_AddAbilities::HandleActorExtension( AActor * actor, FName event_name, int32 entry_index )
 {
     if ( !AbilitiesList.IsValidIndex( entry_index ) )
     {
@@ -182,13 +182,13 @@ void UGASExtGameFeatureAction_Grant::HandleActorExtension( AActor * actor, FName
     {
         RemoveActorAbilities( actor );
     }
-    else if ( event_name == UGameFrameworkComponentManager::NAME_ExtensionAdded || event_name == UGASExtGameFeatureAction_Grant::NAME_AbilityReady )
+    else if ( event_name == UGameFrameworkComponentManager::NAME_ExtensionAdded || event_name == UGASExtGameFeatureAction_AddAbilities::NAME_AbilityReady )
     {
         AddActorAbilities( actor, entry );
     }
 }
 
-void UGASExtGameFeatureAction_Grant::AddActorAbilities( AActor * actor, const FGASExtGameFeatureAbilitiesEntry & abilities_entry )
+void UGASExtGameFeatureAction_AddAbilities::AddActorAbilities( AActor * actor, const FGASExtGameFeatureAbilitiesEntry & abilities_entry )
 {
     if ( auto * ability_system_component = FindOrAddComponentForActor< UAbilitySystemComponent >( actor, abilities_entry ) )
     {
@@ -265,7 +265,7 @@ void UGASExtGameFeatureAction_Grant::AddActorAbilities( AActor * actor, const FG
     }
 }
 
-void UGASExtGameFeatureAction_Grant::RemoveActorAbilities( AActor * actor )
+void UGASExtGameFeatureAction_AddAbilities::RemoveActorAbilities( AActor * actor )
 {
     if ( auto * actor_extensions = ActiveExtensions.Find( actor ) )
     {
@@ -300,7 +300,7 @@ void UGASExtGameFeatureAction_Grant::RemoveActorAbilities( AActor * actor )
     }
 }
 
-UActorComponent * UGASExtGameFeatureAction_Grant::FindOrAddComponentForActor( UClass * component_type, AActor * actor, const FGASExtGameFeatureAbilitiesEntry & abilities_entry )
+UActorComponent * UGASExtGameFeatureAction_AddAbilities::FindOrAddComponentForActor( UClass * component_type, AActor * actor, const FGASExtGameFeatureAbilitiesEntry & abilities_entry )
 {
     auto * component = actor->FindComponentByClass( component_type );
 

--- a/Source/GASExtensions/Public/Abilities/GASExtAbilitySet.h
+++ b/Source/GASExtensions/Public/Abilities/GASExtAbilitySet.h
@@ -2,8 +2,15 @@
 
 #include <CoreMinimal.h>
 #include <Engine/DataAsset.h>
+#include <GameplayAbilitySpec.h>
+#include <GameplayTags.h>
 
 #include "GASExtAbilitySet.generated.h"
+
+class UGASExtGameplayAbility;
+class UGameplayEffect;
+class UAttributeSet;
+class UAbilitySystemComponent;
 
 USTRUCT( BlueprintType )
 struct FGASExtAbilitySet_GameplayAbility

--- a/Source/GASExtensions/Public/Abilities/GASExtAbilitySet.h
+++ b/Source/GASExtensions/Public/Abilities/GASExtAbilitySet.h
@@ -51,7 +51,7 @@ public:
     void AddGameplayEffectHandle( const FActiveGameplayEffectHandle & handle );
     void AddAttributeSet( UAttributeSet * set );
 
-    void TakeFromAbilitySystem( UGASExtAbilitySystemComponent * asc );
+    void TakeFromAbilitySystem( UAbilitySystemComponent * asc );
 
 protected:
     UPROPERTY()
@@ -70,7 +70,7 @@ class GASEXTENSIONS_API UGASExtAbilitySet final : public UPrimaryDataAsset
     GENERATED_BODY()
 
 public:
-    void GiveToAbilitySystem( UGASExtAbilitySystemComponent * asc, FGASExtAbilitySet_GrantedHandles * out_granted_handles, UObject * source_object = nullptr ) const;
+    void GiveToAbilitySystem( UAbilitySystemComponent * asc, FGASExtAbilitySet_GrantedHandles * out_granted_handles, UObject * source_object = nullptr ) const;
 
 protected:
     UPROPERTY( EditDefaultsOnly, Category = "Gameplay Abilities", meta = ( TitleProperty = Ability ) )

--- a/Source/GASExtensions/Public/Abilities/GASExtAbilitySet.h
+++ b/Source/GASExtensions/Public/Abilities/GASExtAbilitySet.h
@@ -18,6 +18,9 @@ struct FGASExtAbilitySet_GameplayAbility
 
     UPROPERTY( EditDefaultsOnly, Meta = ( Categories = "InputTag" ) )
     FGameplayTag InputTag;
+
+    UPROPERTY( EditDefaultsOnly, Meta = ( Categories = "InputTag" ) )
+    int32 InputId;
 };
 
 USTRUCT( BlueprintType )
@@ -42,7 +45,7 @@ struct FGASExtAbilitySet_AttributeSet
 };
 
 USTRUCT( BlueprintType )
-struct FGASExtAbilitySet_GrantedHandles
+struct GASEXTENSIONS_API FGASExtAbilitySet_GrantedHandles
 {
     GENERATED_BODY()
 

--- a/Source/GASExtensions/Public/Abilities/GASExtAbilitySet.h
+++ b/Source/GASExtensions/Public/Abilities/GASExtAbilitySet.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <CoreMinimal.h>
+#include <Engine/DataAsset.h>
+
+#include "GASExtAbilitySet.generated.h"
+
+USTRUCT( BlueprintType )
+struct FGASExtAbilitySet_GameplayAbility
+{
+    GENERATED_BODY()
+
+    UPROPERTY( EditDefaultsOnly )
+    TSubclassOf< UGASExtGameplayAbility > Ability = nullptr;
+
+    UPROPERTY( EditDefaultsOnly )
+    int32 AbilityLevel = 1;
+
+    UPROPERTY( EditDefaultsOnly, Meta = ( Categories = "InputTag" ) )
+    FGameplayTag InputTag;
+};
+
+USTRUCT( BlueprintType )
+struct FGASExtAbilitySet_GameplayEffect
+{
+    GENERATED_BODY()
+
+    UPROPERTY( EditDefaultsOnly )
+    TSubclassOf< UGameplayEffect > GameplayEffect = nullptr;
+
+    UPROPERTY( EditDefaultsOnly )
+    float EffectLevel = 1.0f;
+};
+
+USTRUCT( BlueprintType )
+struct FGASExtAbilitySet_AttributeSet
+{
+    GENERATED_BODY()
+
+    UPROPERTY( EditDefaultsOnly )
+    TSubclassOf< UAttributeSet > AttributeSet;
+};
+
+USTRUCT( BlueprintType )
+struct FGASExtAbilitySet_GrantedHandles
+{
+    GENERATED_BODY()
+
+public:
+    void AddAbilitySpecHandle( const FGameplayAbilitySpecHandle & handle );
+    void AddGameplayEffectHandle( const FActiveGameplayEffectHandle & handle );
+    void AddAttributeSet( UAttributeSet * set );
+
+    void TakeFromAbilitySystem( UGASExtAbilitySystemComponent * asc );
+
+protected:
+    UPROPERTY()
+    TArray< FGameplayAbilitySpecHandle > AbilitySpecHandles;
+
+    UPROPERTY()
+    TArray< FActiveGameplayEffectHandle > GameplayEffectHandles;
+
+    UPROPERTY()
+    TArray< UAttributeSet * > GrantedAttributeSets;
+};
+
+UCLASS()
+class GASEXTENSIONS_API UGASExtAbilitySet final : public UPrimaryDataAsset
+{
+    GENERATED_BODY()
+
+public:
+    void GiveToAbilitySystem( UGASExtAbilitySystemComponent * asc, FGASExtAbilitySet_GrantedHandles * out_granted_handles, UObject * source_object = nullptr ) const;
+
+protected:
+    UPROPERTY( EditDefaultsOnly, Category = "Gameplay Abilities", meta = ( TitleProperty = Ability ) )
+    TArray< FGASExtAbilitySet_GameplayAbility > GrantedGameplayAbilities;
+
+    UPROPERTY( EditDefaultsOnly, Category = "Gameplay Effects", meta = ( TitleProperty = GameplayEffect ) )
+    TArray< FGASExtAbilitySet_GameplayEffect > GrantedGameplayEffects;
+
+    UPROPERTY( EditDefaultsOnly, Category = "Attribute Sets", meta = ( TitleProperty = AttributeSet ) )
+    TArray< FGASExtAbilitySet_AttributeSet > GrantedAttributes;
+};

--- a/Source/GASExtensions/Public/Components/GASExtAbilitySystemComponent.h
+++ b/Source/GASExtensions/Public/Components/GASExtAbilitySystemComponent.h
@@ -7,6 +7,7 @@
 
 #include "GASExtAbilitySystemComponent.generated.h"
 
+class UGASExtAbilitySet;
 class UGASExtAbilityTagRelationshipMapping;
 class UGASExtGameplayAbility;
 
@@ -297,6 +298,10 @@ private:
     // :TODO: Remove EditDefaultsOnly when it can be set through experiences
     UPROPERTY( EditDefaultsOnly )
     UGASExtAbilityTagRelationshipMapping * TagRelationshipMapping;
+
+    // :TODO: Remove when it can be set through pawn data
+    UPROPERTY( EditDefaultsOnly )
+    UGASExtAbilitySet * AbilitySet;
 
     /*
      * For tags not bound to gameplay effects

--- a/Source/GASExtensions/Public/Components/GASExtAbilitySystemComponent.h
+++ b/Source/GASExtensions/Public/Components/GASExtAbilitySystemComponent.h
@@ -287,7 +287,7 @@ private:
 
     // :TODO: Remove when it can be set through pawn data
     UPROPERTY( EditDefaultsOnly )
-    UGASExtAbilitySet * AbilitySet;
+    TArray< const UGASExtAbilitySet * > AbilitySets;
 
     /*
      * For tags not bound to gameplay effects

--- a/Source/GASExtensions/Public/Components/GASExtAbilitySystemComponent.h
+++ b/Source/GASExtensions/Public/Components/GASExtAbilitySystemComponent.h
@@ -184,9 +184,6 @@ public:
     _ATTRIBUTE_SET_CLASS_ * GetAttributeSet();
 
     void GiveAbilitySet();
-
-    void GiveDefaultAbilities();
-    void GiveDefaultEffects();
     void GiveDefaultAttributes();
 
     void SetGiveAbilitiesAndEffectsInBeginPlay( bool give_abilities_and_effects_in_begin_play );
@@ -280,12 +277,6 @@ private:
     void ServerCurrentMontageSetPlayRateForMesh( USkeletalMeshComponent * mesh, UAnimMontage * client_anim_montage, const float play_rate );
     void ServerCurrentMontageSetPlayRateForMesh_Implementation( USkeletalMeshComponent * mesh, UAnimMontage * client_anim_montage, const float play_rate );
     bool ServerCurrentMontageSetPlayRateForMesh_Validate( USkeletalMeshComponent * mesh, UAnimMontage * client_anim_montage, const float play_rate );
-
-    UPROPERTY( EditDefaultsOnly, Category = "Defaults" )
-    TArray< TSubclassOf< UGASExtGameplayAbility > > DefaultAbilities;
-
-    UPROPERTY( EditDefaultsOnly, Category = "Defaults" )
-    TArray< TSubclassOf< UGameplayEffect > > DefaultEffects;
 
     UPROPERTY( EditDefaultsOnly, Category = "Defaults" )
     TSubclassOf< UGameplayEffect > DefaultAttributes;

--- a/Source/GASExtensions/Public/Components/GASExtAbilitySystemComponent.h
+++ b/Source/GASExtensions/Public/Components/GASExtAbilitySystemComponent.h
@@ -183,6 +183,8 @@ public:
     template < typename _ATTRIBUTE_SET_CLASS_ >
     _ATTRIBUTE_SET_CLASS_ * GetAttributeSet();
 
+    void GiveAbilitySet();
+
     void GiveDefaultAbilities();
     void GiveDefaultEffects();
     void GiveDefaultAttributes();

--- a/Source/GASExtensions/Public/Components/GASExtAbilitySystemComponent.h
+++ b/Source/GASExtensions/Public/Components/GASExtAbilitySystemComponent.h
@@ -184,7 +184,6 @@ public:
     _ATTRIBUTE_SET_CLASS_ * GetAttributeSet();
 
     void GiveAbilitySet();
-    void GiveDefaultAttributes();
 
     void SetGiveAbilitiesAndEffectsInBeginPlay( bool give_abilities_and_effects_in_begin_play );
 
@@ -279,13 +278,7 @@ private:
     bool ServerCurrentMontageSetPlayRateForMesh_Validate( USkeletalMeshComponent * mesh, UAnimMontage * client_anim_montage, const float play_rate );
 
     UPROPERTY( EditDefaultsOnly, Category = "Defaults" )
-    TSubclassOf< UGameplayEffect > DefaultAttributes;
-
-    UPROPERTY( EditDefaultsOnly, Category = "Defaults" )
     uint8 bGiveAbilitiesAndEffectsInBeginPlay : 1;
-
-    UPROPERTY( EditDefaultsOnly )
-    TArray< TSubclassOf< UAttributeSet > > AdditionalAttributeSetClass;
 
     // If set, this table is used to look up tag relationships for activate and cancel
     // :TODO: Remove EditDefaultsOnly when it can be set through experiences

--- a/Source/GASExtensions/Public/GameFeatures/GASExtGameFeatureAction_AddAbilities.h
+++ b/Source/GASExtensions/Public/GameFeatures/GASExtGameFeatureAction_AddAbilities.h
@@ -2,11 +2,13 @@
 
 #include "Components/GameFrameworkComponentManager.h"
 #include "GFEGameFeatureAction_WorldActionBase.h"
+#include "Abilities/GASExtAbilitySet.h"
 
 #include <CoreMinimal.h>
 
 #include "GASExtGameFeatureAction_AddAbilities.generated.h"
 
+class UGASExtAbilitySet;
 struct FGameFeatureDeactivatingContext;
 
 // This comes from the sample ValleyOfTheAncient
@@ -60,6 +62,9 @@ struct FGASExtGameFeatureAbilitiesEntry
     UPROPERTY( EditAnywhere, Category = "Attributes" )
     TArray< FGASExtGameFeatureAttributesMapping > GrantedAttributes;
 
+    UPROPERTY( EditAnywhere, Category = "Attributes", meta = ( AssetBundles = "Client,Server" ) )
+    TArray< TSoftObjectPtr< const UGASExtAbilitySet > > GrantedAbilitySets;
+
     UPROPERTY( EditAnywhere, Category = "Tags" )
     FGameplayTagContainer LooseGameplayTags;
 };
@@ -107,6 +112,7 @@ private:
         TArray< FGameplayAbilitySpecHandle > Abilities;
         TArray< UAttributeSet * > Attributes;
         TArray< FActiveGameplayEffectHandle > Effects;
+        TArray< FGASExtAbilitySet_GrantedHandles > AbilitySetHandles;
         FGameplayTagContainer Tags;
     };
     TMap< AActor *, FActorExtensions > ActiveExtensions;

--- a/Source/GASExtensions/Public/GameFeatures/GASExtGameFeatureAction_AddAbilities.h
+++ b/Source/GASExtensions/Public/GameFeatures/GASExtGameFeatureAction_AddAbilities.h
@@ -5,7 +5,7 @@
 
 #include <CoreMinimal.h>
 
-#include "GASExtGameFeatureAction_Grant.generated.h"
+#include "GASExtGameFeatureAction_AddAbilities.generated.h"
 
 struct FGameFeatureDeactivatingContext;
 
@@ -64,8 +64,8 @@ struct FGASExtGameFeatureAbilitiesEntry
     FGameplayTagContainer LooseGameplayTags;
 };
 
-UCLASS()
-class GASEXTENSIONS_API UGASExtGameFeatureAction_Grant final : public UGFEGameFeatureAction_WorldActionBase
+UCLASS( meta = ( DisplayName = "Add Abilities" ) )
+class GASEXTENSIONS_API UGASExtGameFeatureAction_AddAbilities final : public UGFEGameFeatureAction_WorldActionBase
 {
     GENERATED_BODY()
 
@@ -110,6 +110,5 @@ private:
         FGameplayTagContainer Tags;
     };
     TMap< AActor *, FActorExtensions > ActiveExtensions;
-
     TArray< TSharedPtr< FComponentRequestHandle > > ComponentRequests;
 };


### PR DESCRIPTION
- Copy pasted Lyra gameplay cue manager
- CS
- logs update
- Added GASExtAbilityTagRelationshipMapping
- Use ability tag relationship mapping in GAS and GA
- Added setter for TagRelationshipMapping in GASExtASC
- virtual function to let projects add their own blocked tags
- Added UGASExtGameFeatureAction_Grant::NAME_AbilityReady
- Temporarily added EditDefaultsOnly modifier to TagRelationshipMapping
- CS
- CS
- Renamed GASExtGameFeatureAction_Grant to GASExtGameFeatureAction_AddAbilities
- Added GASExtAbilitySet
- Updated GASExtGameFeatureAction_AddAbilities to add ability sets
- Temporarily added AbilitySet to ASC
- Temporarily added int32 InputId to FGASExtAbilitySet_GameplayAbility
- Add abilities / effects from AbilitySet
- Removed old DefaultAbilities and DefaultEffects
- Removed unused stuff
- Changed AbilitySet to array of sets
