### PR TITLE
effect_container_set_by_caller_tags

### DIFF
--- a/Source/GASExtensions/Private/GASExtAbilitySystemFunctionLibrary.cpp
+++ b/Source/GASExtensions/Private/GASExtAbilitySystemFunctionLibrary.cpp
@@ -25,6 +25,12 @@ FGASExtGameplayEffectContainerSpec UGASExtAbilitySystemFunctionLibrary::MakeEffe
             if ( ensureAlwaysMsgf( gameplay_effect_class != nullptr, TEXT( "Can not provide a null class in the TargetEffectClasses of the gameplay effect container" ) ) )
             {
                 const auto gameplay_effect_spec_handle = ability->MakeOutgoingGameplayEffectSpec( gameplay_effect_class, static_cast< float >( level ) );
+
+                for ( const auto & [ tag, magnitude ] : effect_container.SetByCallerTagsToMagnitudeMap )
+                {
+                    gameplay_effect_spec_handle.Data.Get()->SetSetByCallerMagnitude( tag, magnitude.GetValue() );
+                }
+
                 if ( auto * context = static_cast< FGASExtGameplayEffectContext * >( gameplay_effect_spec_handle.Data->GetContext().Get() ) )
                 {
                     context->SetFallOffType( effect_container.FallOffType );

--- a/Source/GASExtensions/Private/GASExtAbilitySystemFunctionLibrary.cpp
+++ b/Source/GASExtensions/Private/GASExtAbilitySystemFunctionLibrary.cpp
@@ -180,3 +180,22 @@ TSubclassOf< UGameplayEffect > UGASExtAbilitySystemFunctionLibrary::GetGameplayE
 
     return nullptr;
 }
+
+void UGASExtAbilitySystemFunctionLibrary::CopySetByCallerTagMagnitudesFromSpecToConditionalEffects( FGameplayEffectSpec * gameplay_effect_spec )
+{
+    if ( gameplay_effect_spec == nullptr )
+    {
+        return;
+    }
+
+    for ( auto handle : gameplay_effect_spec->TargetEffectSpecs )
+    {
+        if ( !handle.Data.IsValid() )
+        {
+            continue;
+        }
+
+        handle.Data->SetByCallerTagMagnitudes.Append( gameplay_effect_spec->SetByCallerTagMagnitudes );
+        CopySetByCallerTagMagnitudesFromSpecToConditionalEffects( handle.Data.Get() );
+    }
+}

--- a/Source/GASExtensions/Private/GASExtAbilitySystemFunctionLibrary.cpp
+++ b/Source/GASExtensions/Private/GASExtAbilitySystemFunctionLibrary.cpp
@@ -199,3 +199,24 @@ void UGASExtAbilitySystemFunctionLibrary::CopySetByCallerTagMagnitudesFromSpecTo
         CopySetByCallerTagMagnitudesFromSpecToConditionalEffects( handle.Data.Get() );
     }
 }
+
+void UGASExtAbilitySystemFunctionLibrary::AddDynamicAssetTagToSpecAndChildren( FGameplayEffectSpec * gameplay_effect_spec, const FGameplayTag gameplay_tag )
+{
+    if ( gameplay_effect_spec == nullptr )
+    {
+        return;
+    }
+
+    gameplay_effect_spec->AddDynamicAssetTag( gameplay_tag );
+
+    for ( auto handle : gameplay_effect_spec->TargetEffectSpecs )
+    {
+        if ( !handle.Data.IsValid() )
+        {
+            continue;
+        }
+
+        handle.Data->AddDynamicAssetTag( gameplay_tag );
+        AddDynamicAssetTagToSpecAndChildren( handle.Data.Get(), gameplay_tag );
+    }
+}

--- a/Source/GASExtensions/Private/Targeting/GASExtTargetingHelperLibrary.cpp
+++ b/Source/GASExtensions/Private/Targeting/GASExtTargetingHelperLibrary.cpp
@@ -14,15 +14,15 @@ namespace
         const auto camera_to_center = ability_center - camera_location;
         const auto dot_to_center = FVector::DotProduct( camera_to_center, camera_direction );
 
-        if ( dot_to_center >= 0 ) //If this fails, we're pointed away from the center, but we might be inside the sphere and able to find a good exit point.
+        if ( dot_to_center >= 0 ) // If this fails, we're pointed away from the center, but we might be inside the sphere and able to find a good exit point.
         {
             const auto distance_squared = camera_to_center.SizeSquared() - ( dot_to_center * dot_to_center );
             const auto radius_squared = ( ability_range * ability_range );
             if ( distance_squared <= radius_squared )
             {
                 const auto distance_from_camera = FMath::Sqrt( radius_squared - distance_squared );
-                const auto distance_along_ray = dot_to_center + distance_from_camera;           //Subtracting instead of adding will get the other intersection point
-                clipped_position = camera_location + ( distance_along_ray * camera_direction ); //Cam aim point clipped to range sphere
+                const auto distance_along_ray = dot_to_center + distance_from_camera;           // Subtracting instead of adding will get the other intersection point
+                clipped_position = camera_location + ( distance_along_ray * camera_direction ); // Cam aim point clipped to range sphere
                 return true;
             }
         }

--- a/Source/GASExtensions/Public/GASExtAbilitySystemFunctionLibrary.h
+++ b/Source/GASExtensions/Public/GASExtAbilitySystemFunctionLibrary.h
@@ -59,4 +59,5 @@ public:
     static TSubclassOf< UGameplayEffect > GetGameplayEffectClassFromSpecHandle( FGameplayEffectSpecHandle spec_handle );
 
     static void CopySetByCallerTagMagnitudesFromSpecToConditionalEffects( FGameplayEffectSpec * gameplay_effect_spec );
+    static void AddDynamicAssetTagToSpecAndChildren( FGameplayEffectSpec * gameplay_effect_spec, FGameplayTag gameplay_tag );
 };

--- a/Source/GASExtensions/Public/GASExtAbilitySystemFunctionLibrary.h
+++ b/Source/GASExtensions/Public/GASExtAbilitySystemFunctionLibrary.h
@@ -57,4 +57,6 @@ public:
 
     UFUNCTION( BlueprintPure, Category = "Ability|GameplayEffects" )
     static TSubclassOf< UGameplayEffect > GetGameplayEffectClassFromSpecHandle( FGameplayEffectSpecHandle spec_handle );
+
+    static void CopySetByCallerTagMagnitudesFromSpecToConditionalEffects( FGameplayEffectSpec * gameplay_effect_spec );
 };

--- a/Source/GASExtensions/Public/GASExtAbilityTypesBase.h
+++ b/Source/GASExtensions/Public/GASExtAbilityTypesBase.h
@@ -107,6 +107,9 @@ struct GASEXTENSIONS_API FGASExtGameplayEffectContainer
     EGASExtGetTargetDataExecutionType TargetDataExecutionType;
 
     UPROPERTY( EditAnywhere, BlueprintReadOnly, Category = "GameplayEffectContainer" )
+    TMap< FGameplayTag, FScalableFloat > SetByCallerTagsToMagnitudeMap;
+
+    UPROPERTY( EditAnywhere, BlueprintReadOnly, Category = "GameplayEffectContainer" )
     TArray< TSubclassOf< UGameplayEffect > > TargetGameplayEffectClasses;
 
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = "GameplayEffectContainer" )


### PR DESCRIPTION
- Add function to get GE class from spec handle
- Remove UFUNCTION and add comments
- Remove UFUNCTION
- PR review
- Add bool to set if we want to use hit result for the effect application or not
- Splite sphere overlap in 2 classes
- Removed MakeEffectContainerSpecFromEffectContainer from GASExtGameplayAbility
- Added new parameter to pass level of the GE
- Create task
- Fixup task
- Create task class
- Implement progression in delay task
- Small fixes
- Fix issue where skip time did not affect the first update time
- PR fixes
- Revert "Merge remote-tracking branch 'origin/develop' into wait_ability_end_task"
- Revert "Merge pull request #67 from TheEmidee/wait_ability_end_task"
- Added new property to FGASExtGameplayEffectContainer
- coding standard
- Created function to fill conditional effects with the same SetByCallerTagMagnitudes as their parent
- Created function to add dynamic tag to a gameplay effect spec and it's conditional GEs
